### PR TITLE
Fix magnetometer unit conversion.

### DIFF
--- a/src/lpms_imu_node.cpp
+++ b/src/lpms_imu_node.cpp
@@ -122,9 +122,10 @@ class LpImuProxy
             mag_msg.header.stamp = imu_msg.header.stamp;
             mag_msg.header.frame_id = frame_id;
 
-            mag_msg.magnetic_field.x = data.b[0]*9.81;
-            mag_msg.magnetic_field.y = data.b[1]*9.81;
-            mag_msg.magnetic_field.z = data.b[2]*9.81;
+            // Units are microTesla in the LPMS library, Tesla in ROS.
+            mag_msg.magnetic_field.x = data.b[0]*1e-6;
+            mag_msg.magnetic_field.y = data.b[1]*1e-6;
+            mag_msg.magnetic_field.z = data.b[2]*1e-6;
 
             // Publish the messages
             imu_pub.publish(imu_msg);


### PR DESCRIPTION
Hi,
I had a quick look into your ROS driver which seems very useful for people who want to use our sensors together with ROS.  Doing this I stumbled over a weird factor 9.81 in the conversion of the magnetic field data.  After comparison of our (i.e., LP-Research's, we use microTesla) and ROS's (uses Tesla) docs, I believe the correct factor is better approximated by 1e-6 :)

Have you decided what the license of the code should be?

Cheers,
- Tobi